### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/egvimo/python-scripts/security/code-scanning/1](https://github.com/egvimo/python-scripts/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, specifying the least privileges required for the tasks in the workflow. In this case, the workflow only needs to check out the code and run tests and linting, so it only requires read access to repository contents. The best fix is to add `permissions: contents: read` either at the top-level of the workflow or within the job itself if you want to scope it to individual jobs. Given that there's just one job, it's simplest to add this at the root level, right under the `name` field and before the `on:` field. No new methods or imports are needed—inserting the configuration line suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
